### PR TITLE
Change the check answers page to show all questions

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -14,16 +14,20 @@ $govuk-global-styles: true;
 
 // Add extra styles here, or re-organise the Sass files in whichever way makes most sense to you
 
-.wide .govuk-summary-list__row .govuk-summary-list__key {
-  width: 68%;
-}
+// Changed widths because the check answers screen shows all the
+// questions and some are quite long
+@include govuk-media-query($from: tablet) {
+  .govuk-summary-list__row .govuk-summary-list__key {
+    width: 55%;
+  }
 
-.wide .govuk-summary-list__row .govuk-summary-list__value {
-  width: 20%;
-}
+  .govuk-summary-list__row .govuk-summary-list__value {
+    width: 30%;
+  }
 
-.wide .govuk-summary-list__row .govuk-summary-list__actions {
-  width: 12%;
+  .govuk-summary-list__row .govuk-summary-list__actions {
+    width: 15%;
+  }
 }
 
 .answer-incomplete {

--- a/app/routes.js
+++ b/app/routes.js
@@ -6,7 +6,7 @@ const router = express.Router()
 router.post('/supply-teacher', function (req, res) {
   let supplyTeacher = req.session.data['supplyTeacher']
 
-  if (supplyTeacher === 'false') {
+  if (supplyTeacher === 'No') {
     res.redirect('/qualified')
   } else {
     res.redirect('/supply-teacher-term')
@@ -16,7 +16,7 @@ router.post('/supply-teacher', function (req, res) {
 router.post('/supply-teacher-term', function (req, res) {
   let supplyTeacherTerm = req.session.data['supplyTeacherTerm']
 
-  if (supplyTeacherTerm === 'false') {
+  if (supplyTeacherTerm === 'No') {
     res.redirect('/ineligible-term')
   } else {
     res.redirect('/private-agency')
@@ -26,7 +26,7 @@ router.post('/supply-teacher-term', function (req, res) {
 router.post('/private-agency', function (req, res) {
   let supplyTeacherAgency = req.session.data['supplyTeacherAgency']
 
-  if (supplyTeacherAgency === 'false') {
+  if (supplyTeacherAgency === 'No') {
     res.redirect('/qualified')
   } else {
     res.redirect('/ineligible-agency')
@@ -36,7 +36,7 @@ router.post('/private-agency', function (req, res) {
 router.post('/qualified', function (req, res) {
   let qualified = req.session.data['qualified']
 
-  if (qualified === 'false') {
+  if (qualified === 'No') {
     res.redirect('/ineligible-qualified')
   } else {
     res.redirect('/subject')
@@ -46,7 +46,7 @@ router.post('/qualified', function (req, res) {
 router.post('/subject', function (req, res) {
   let teachingSubject = req.session.data['teachingSubject']
 
-  if (teachingSubject === 'false') {
+  if (teachingSubject === 'No') {
     res.redirect('/ineligible-subject')
   } else {
     res.redirect('/awarded')
@@ -56,7 +56,7 @@ router.post('/subject', function (req, res) {
 router.post('/awarded', function (req, res) {
   let awarded = req.session.data['awarded']
 
-  if (awarded === 'false') {
+  if (awarded === 'Before 1 September 2014') {
     res.redirect('/ineligible-awarded')
   } else {
     res.redirect('/school')
@@ -79,7 +79,7 @@ router.post('/school', function (req, res) {
 router.post('/disciplinary', function (req, res) {
   let teacherAction = req.session.data['teacherAction']
 
-  if (teacherAction === 'false') {
+  if (teacherAction === 'No') {
     res.redirect('/verify')
   } else {
     res.redirect('/ineligible-disciplinary')

--- a/app/views/awarded.html
+++ b/app/views/awarded.html
@@ -25,14 +25,14 @@
           },
           items: [
             {
-              value: "true",
+              value: "On or after 1 September 2014",
               text: "On or after 1 September 2014",
               attributes: {
                 required: "true"
               }
             },
             {
-              value: "false",
+              value: "Before 1 September 2014",
               text: "Before 1 September 2014"
             }
           ]

--- a/app/views/check-answers.html
+++ b/app/views/check-answers.html
@@ -23,53 +23,188 @@
 
       <h1 class="govuk-heading-xl">Check your answers before sending your application</h1>
 
-      {% set schoolName =  data['school-name'] %}
+      <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+        {% if data['supplyTeacher'] %}
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Are you currently employed as a supply teacher?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['supplyTeacher'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link" href="/supply-teacher">
+              Change<span class="govuk-visually-hidden"> your answer</span>
+            </a>
+          </dd>
+        </div>
+        {% endif %}
 
-      {{ govukSummaryList({
-        classes: 'govuk-!-margin-bottom-9',
-        rows: [
-          {
-            key: {
-              text: "School"
-            },
-            value: {
-              text: schoolName
-            },
-            actions: {
-              items: [
-                {
-                  href: "/teacher-location",
-                  text: "Change",
-                  visuallyHiddenText: "school-name"
-                }
-              ]
-            }
-          },
-          {
-            key: {
-              text: "Contact details"
-            },
-            value: {
-              html: '<p class="govuk-body">' + data['contactEmail'] + '</p>' + '<p class="govuk-body">' +data['contactPhone'] + '</p>' + '<p class="govuk-body">' + data['contactText'] + '</p>'
-            },
-            actions: {
-              items: [
-                {
-                  href: "teacher-contact-method",
-                  text: "Change",
-                  visuallyHiddenText: "contact details"
-                }
-              ]
-            }
-          }
-        ]
-      }) }}
+        {% if data['supplyTeacherTerm'] %}
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Are you employed as a supply teacher for more than one term?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['supplyTeacherTerm'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link" href="/supply-teacher-term">
+              Change<span class="govuk-visually-hidden"> your answer</span>
+            </a>
+          </dd>
+        </div>
+        {% endif %}
+
+        {% if data['supplyTeacherAgency'] %}
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Are you employed as a supply teacher by a private agency?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['supplyTeacherAgency'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link" href="/supply-teacher-agency">
+              Change<span class="govuk-visually-hidden"> your answer</span>
+            </a>
+          </dd>
+        </div>
+        {% endif %}
+
+        {% if data['qualified'] %}
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Are you qualified to teach Mathematics and/or Physics?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['qualified'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link" href="/qualified">
+              Change<span class="govuk-visually-hidden"> your answer</span>
+            </a>
+          </dd>
+        </div>
+        {% endif %}
+
+        {% if data['teachingSubject'] %}
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Do you currently teach Mathematics and/or Physics?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['teachingSubject'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link" href="/subject">
+              Change<span class="govuk-visually-hidden"> your answer</span>
+            </a>
+          </dd>
+        </div>
+        {% endif %}
+
+        {% if data['awarded'] %}
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            When were you awarded your QTS or QTLS?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['awarded'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link" href="/awarded">
+              Change<span class="govuk-visually-hidden"> when were you awarded your QTS or QTLS</span>
+            </a>
+          </dd>
+        </div>
+        {% endif %}
+
+        {% if data['school-name'] %}
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            School
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['school-name'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link" href="/school">
+              Change<span class="govuk-visually-hidden"> your school</span>
+            </a>
+          </dd>
+        </div>
+        {% endif %}
+
+        {% if data['teacherAction'] %}
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Are you currently subject to formal capability proceedings or disciplinary action?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['teacherAction'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link" href="/disciplinary">
+              Change<span class="govuk-visually-hidden"> your answer</span>
+            </a>
+          </dd>
+        </div>
+        {% endif %}
+
+        {% if data['trn'] %}
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            What's your teacher reference number?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['trn'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link" href="/teacher-reference-number">
+              Change<span class="govuk-visually-hidden"> your teacher reference number</span>
+            </a>
+          </dd>
+        </div>
+        {% endif %}
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Your account details
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <p class="govuk-body">{{ data['account-holder'] }}</p>
+            <p class="govuk-body">Account number:<br>{{ data['account-number'] }}</p>
+            <p class="govuk-body">Sort code:<br>{{ data['sort-code'] }}</p>
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link" href="/teacher-reference-number">
+              Change<span class="govuk-visually-hidden"> your account details</span>
+            </a>
+          </dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Contact details
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {% if data['contactEmail'] %}<p class="govuk-body">{{ data['contactEmail'] }}</p>{% endif %}
+            {% if data['contactText'] %}<p class="govuk-body">{{ data['contactText'] }}</p>{% endif %}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link" href="/teacher-reference-number">
+              Change<span class="govuk-visually-hidden"> your contact details</span>
+            </a>
+          </dd>
+        </div>
+      </dl>
 
       <h2 class="govuk-heading-m">Confirm your claim</h2>
 
       <p class="govuk-body">By submitting this claim you are confirming that, to the best of your knowledge, the details you are providing are correct.</p>
 
-      <form action="/teacher-success" method="post" novalidate>
+      <form action="/success" method="post" novalidate>
 
         <input type="hidden" name="answers-checked" value="true">
 

--- a/app/views/check.html
+++ b/app/views/check.html
@@ -16,7 +16,7 @@
       <ul class="govuk-list govuk-list--bullet">
         <li>have qualified as a teacher after
             1 September 2014                    </li>
-        <li>have a qualification with a specialism in either Physics or Mathamatics</li>
+        <li>have a qualification with a specialism in either Physics or Mathematics</li>
         <li>still be teaching in a school in the UK</li>
         <li>have worked in a participating local authority area in England in the last academic year, at either:
             <ul>

--- a/app/views/consent.html
+++ b/app/views/consent.html
@@ -17,7 +17,7 @@
       <ul class="govuk-list govuk-list--bullet">
         <li>that you taught there</li>
         <li>the subject you were employed to teach</li>
-        <li>you have a qualification specialising in either Physics or Mathamatics</li>
+        <li>you have a qualification specialising in either Physics or Mathematics</li>
       </ul>
 
       <p>We cannot process your claim without doing this.</p>

--- a/app/views/disciplinary.html
+++ b/app/views/disciplinary.html
@@ -25,14 +25,14 @@
           },
           items: [
             {
-              value: "true",
+              value: "Yes",
               text: "Yes",
               attributes: {
                 required: "true"
               }
             },
             {
-              value: "false",
+              value: "No",
               text: "No"
             }
           ]

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -9,7 +9,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">DfE Mathamatics and Physics Service Prototypes</h1>
+      <h1 class="govuk-heading-xl">DfE Mathematics and Physics Service Prototypes</h1>
       <h2 class="govuk-heading-l">Latest and archived prototypes</h2>
     </div>
   </div>

--- a/app/views/ineligible-qualified.html
+++ b/app/views/ineligible-qualified.html
@@ -13,7 +13,7 @@
         You’re not eligible to claim
       </h1>
       <p class="govuk-body">Based on your answers, you're not eligible to claim.</p>
-      <p class="govuk-body">You must be qualified to teach Mathamatics and/or Physics to be eligible.</p>
+      <p class="govuk-body">You must be qualified to teach Mathematics and/or Physics to be eligible.</p>
       <p class="govuk-body"><a href="/" class="govuk-link">Return to the gov.uk homepage</a></p>
     </div>
   </div>

--- a/app/views/ineligible-subject.html
+++ b/app/views/ineligible-subject.html
@@ -13,7 +13,7 @@
         You’re not eligible to claim
       </h1>
       <p class="govuk-body">Based on your answers, you're not eligible to claim.</p>
-      <p class="govuk-body">You need to be currently teaching Mathamatics and/or Physics to be eligible. This can be as part of a broader curriculum.</p>
+      <p class="govuk-body">You need to be currently teaching Mathematics and/or Physics to be eligible. This can be as part of a broader curriculum.</p>
       <p class="govuk-body"><a href="/" class="govuk-link">Return to the gov.uk homepage</a></p>
     </div>
   </div>

--- a/app/views/payment-method.html
+++ b/app/views/payment-method.html
@@ -46,8 +46,8 @@
             hint: {
               text: "For example: 44 00 26"
             },
-            id: "sort-code-1",
-            name: "sort-code-1",
+            id: "sort-code",
+            name: "sort-code",
             pattern: "[0-9]{6}",
             classes: "govuk-!-width-one-quarter"
           }) }}

--- a/app/views/private-agency.html
+++ b/app/views/private-agency.html
@@ -27,14 +27,14 @@
           name: "supplyTeacherAgency",
           items: [
             {
-              value: "true",
+              value: "Yes",
               text: "Yes",
               attributes: {
                 required: "true"
               }
             },
             {
-              value: "false",
+              value: "No",
               text: "No"
             }
           ]

--- a/app/views/qualified.html
+++ b/app/views/qualified.html
@@ -18,7 +18,7 @@
           name: "qualified",
           fieldset: {
             legend: {
-              text: "Are you qualified to teach Mathamatics and/or Physics?",
+              text: "Are you qualified to teach Mathematics and/or Physics?",
               isPageHeading: true,
               classes: "govuk-fieldset__legend--xl"
             }
@@ -28,11 +28,11 @@
           },
           items: [
             {
-              value: "true",
+              value: "Yes",
               text: "Yes"
             },
             {
-              value: "false",
+              value: "No",
               text: "No"
             }
           ]

--- a/app/views/school.html
+++ b/app/views/school.html
@@ -10,7 +10,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">
-        Which shcool are you currently employed to teach at?
+        Which school are you currently employed to teach at?
       </h1>
 
       <form method="POST" action="school">

--- a/app/views/subject.html
+++ b/app/views/subject.html
@@ -18,24 +18,24 @@
           name: "teachingSubject",
           fieldset: {
             legend: {
-              text: "Do you currently teach Mathamatics and/or Physics?",
+              text: "Do you currently teach Mathematics and/or Physics?",
               isPageHeading: true,
               classes: "govuk-fieldset__legend--xl"
             }
           },
           hint: {
-            text: "You can teach Mathamatics/Physics as part of a broader curriculum"
+            text: "You can teach Mathematics/Physics as part of a broader curriculum"
           },
           items: [
             {
-              value: "true",
+              value: "Yes",
               text: "Yes",
               attributes: {
                 required: "true"
               }
             },
             {
-              value: "false",
+              value: "No",
               text: "No"
             }
           ]

--- a/app/views/supply-teacher-term.html
+++ b/app/views/supply-teacher-term.html
@@ -25,14 +25,14 @@
           },
           items: [
             {
-              value: "true",
+              value: "Yes",
               text: "Yes",
               attributes: {
                 required: "true"
               }
             },
             {
-              value: "false",
+              value: "No",
               text: "No"
             }
           ]

--- a/app/views/supply-teacher.html
+++ b/app/views/supply-teacher.html
@@ -25,14 +25,14 @@
           },
           items: [
             {
-              value: "true",
+              value: "Yes",
               text: "Yes",
               attributes: {
                 required: "true"
               }
             },
             {
-              value: "false",
+              value: "No",
               text: "No"
             }
           ]


### PR DESCRIPTION
The check answers page should show all the questions the user has
answered. It checks to see if the question input has a value, and will
then show it if it does.

- Changed the values to inputs to be human readable, Yes instead of
true, No instead of false

- Rewrite the check-answers page so it uses HTML instead of nunjucks to
render the table of answers so that we only show a question of the user
answered it