### PR TITLE
(fix) issue with accessible autocomplete using incorrect font

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -9,8 +9,8 @@ $govuk-global-styles: true;
 @import "patterns/task-list";
 @import "patterns/related-items";
 
-// Components that aren't in Frontend
-@import "components/cookie-banner";
+// Tweaks to Accessible Auto Complete
+@import "components/select-input";
 
 // Add extra styles here, or re-organise the Sass files in whichever way makes most sense to you
 
@@ -34,4 +34,10 @@ $govuk-global-styles: true;
   color: #666;
   display: block;
   font-size: 16px;
+}
+
+.govuk-form-group{
+  li {
+      font-family: "nta", Arial, sans-serif;
+  }
 }

--- a/app/assets/sass/components/_select-input.scss
+++ b/app/assets/sass/components/_select-input.scss
@@ -1,0 +1,5 @@
+.govuk-form-group{
+    .autocomplete__option{
+        font-family: "nta", Arial, sans-serif;
+    }
+}


### PR DESCRIPTION
- Added in SCSS file to hold all fixes for accessibility autocomplete,
  applied fix to all li in the autocompletes

- Set application.scss to pull in fixes by default.