### PR TITLE
Add student loan questions

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -125,9 +125,7 @@ router.post('/student-loan-repayment', function (req, res) {
 
 router.post('/student-loan-plan', function (req, res) {
   let studentLoanPlan = req.session.data['studentLoanPlan']
-
   if (studentLoanPlan === 'I do not know') {
-    if (req.session.data.edited) res.redirect('/check-answers')
     res.redirect('/education-country')
   } else {
     if (req.session.data.edited) res.redirect('/check-answers')
@@ -135,17 +133,11 @@ router.post('/student-loan-plan', function (req, res) {
   }
 })
 
-router.post('/education-country', function (req, res) {
-  if (req.session.data.edited) res.redirect('/check-answers')
-  res.redirect('/number-of-courses')
-})
-
 router.post('/number-of-courses', function (req, res) {
   let numberOfCourses = req.session.data['numberOfCourses']
   if (numberOfCourses === '2 or more courses') {
     res.redirect('/multiple-courses-start')
   }
-  if (req.session.data.edited) res.redirect('/check-answers')
   res.redirect('/course-start')
 })
 
@@ -155,9 +147,30 @@ router.post('/course-start', function (req, res) {
 })
 
 router.post('/multiple-courses-start', function (req, res) {
-  let studentLoanPlan = req.session.data['studentLoanPlan']
-  if (req.session.data.edited) res.redirect('/check-answers')
-  res.redirect('/payment-method')
+  let multipleCoursesStart = req.session.data['multipleCoursesStart']
+  if (multipleCoursesStart === '1') {
+    req.session.data['studentLoanPlan'] = 'Plan 1';
+    if (req.session.data.edited) res.redirect('/check-answers')
+    res.redirect('/payment-method')
+  } else if (multipleCoursesStart === '2'){
+    req.session.data['studentLoanPlan'] = 'Plan 1 and 2';
+    if (req.session.data.edited) res.redirect('/check-answers')
+    res.redirect('/payment-method')
+  } else {
+    req.session.data['studentLoanPlan'] = 'Plan 2';
+    if (req.session.data.edited) res.redirect('/check-answers')
+    res.redirect('/payment-method')
+  }
+})
+
+router.post('/education-country', function (req, res) {
+  let countryLoanPlan = req.session.data['countryLoanPlan']
+  if (countryLoanPlan === 'Scotland' || countryLoanPlan === 'Northern Ireland') {
+    req.session.data['studentLoanPlan'] = 'Plan 1';
+    res.redirect('/payment-method')
+  } else {
+    res.redirect('/number-of-courses')
+  }
 })
 
 router.get('/reference-number', function (req, res) {

--- a/app/routes.js
+++ b/app/routes.js
@@ -152,8 +152,17 @@ router.post('/number-of-courses', function (req, res) {
 })
 
 router.post('/course-start', function (req, res) {
-  if (req.session.data.edited) res.redirect('/check-answers')
-  res.redirect('/payment-method')
+  let courseStart = req.session.data['courseStart']
+
+  if (courseStart === '1') {
+    req.session.data['studentLoanPlan'] = 'Plan 1';
+    if (req.session.data.edited) res.redirect('/check-answers')
+    res.redirect('/payment-method')
+  } else {
+    req.session.data['studentLoanPlan'] = 'Plan 2';
+    if (req.session.data.edited) res.redirect('/check-answers')
+    res.redirect('/payment-method')
+  }
 })
 
 router.post('/multiple-courses-start', function (req, res) {
@@ -177,6 +186,7 @@ router.post('/education-country', function (req, res) {
   let countryLoanPlan = req.session.data['countryLoanPlan']
   if (countryLoanPlan === 'Scotland' || countryLoanPlan === 'Northern Ireland') {
     req.session.data['studentLoanPlan'] = 'Plan 1';
+    if (req.session.data.edited) res.redirect('/check-answers')
     res.redirect('/payment-method')
   } else {
     res.redirect('/number-of-courses')

--- a/app/routes.js
+++ b/app/routes.js
@@ -113,11 +113,39 @@ router.get('/check-answers', function (req, res) {
   res.render('check-answers')
 })
 
-router.get('/national-insurance-number', function (req, res) {
-  res.render('national-insurance-number')
+router.post('/national-insurance-number', function (req, res) {
+  if (req.session.data.edited) res.redirect('/check-answers')
+  res.redirect('/student-loan-repayment')
 })
 
-router.post('/national-insurance-number', function (req, res) {
+router.post('/student-loan-repayment', function (req, res) {
+  if (req.session.data.edited) res.redirect('/check-answers')
+  res.redirect('/student-loan-plan')
+})
+
+router.post('/student-loan-plan', function (req, res) {
+  let studentLoanPlan = req.session.data['studentLoanPlan']
+
+  if (studentLoanPlan === 'I do not know') {
+    if (req.session.data.edited) res.redirect('/check-answers')
+    res.redirect('/education-country')
+  } else {
+    if (req.session.data.edited) res.redirect('/check-answers')
+    res.redirect('/payment-method')
+  }
+})
+
+router.post('/education-country', function (req, res) {
+  if (req.session.data.edited) res.redirect('/check-answers')
+  res.redirect('/number-of-courses')
+})
+
+router.post('/number-of-courses', function (req, res) {
+  if (req.session.data.edited) res.redirect('/check-answers')
+  res.redirect('/course-start')
+})
+
+router.post('/course-start', function (req, res) {
   if (req.session.data.edited) res.redirect('/check-answers')
   res.redirect('/payment-method')
 })

--- a/app/routes.js
+++ b/app/routes.js
@@ -141,11 +141,21 @@ router.post('/education-country', function (req, res) {
 })
 
 router.post('/number-of-courses', function (req, res) {
+  let numberOfCourses = req.session.data['numberOfCourses']
+  if (numberOfCourses === '2 or more courses') {
+    res.redirect('/multiple-courses-start')
+  }
   if (req.session.data.edited) res.redirect('/check-answers')
   res.redirect('/course-start')
 })
 
 router.post('/course-start', function (req, res) {
+  if (req.session.data.edited) res.redirect('/check-answers')
+  res.redirect('/payment-method')
+})
+
+router.post('/multiple-courses-start', function (req, res) {
+  let studentLoanPlan = req.session.data['studentLoanPlan']
   if (req.session.data.edited) res.redirect('/check-answers')
   res.redirect('/payment-method')
 })

--- a/app/routes.js
+++ b/app/routes.js
@@ -115,7 +115,7 @@ router.get('/check-answers', function (req, res) {
 
 router.post('/national-insurance-number', function (req, res) {
   if (req.session.data.edited) res.redirect('/check-answers')
-  res.redirect('/student-loan-repayment')
+  res.redirect('/education-country')
 })
 
 router.post('/student-loan-repayment', function (req, res) {

--- a/app/routes.js
+++ b/app/routes.js
@@ -6,7 +6,6 @@ const router = express.Router()
 router.post('/supply-teacher', function (req, res) {
   let supplyTeacher = req.session.data['supplyTeacher']
 
-
   if (supplyTeacher === 'No') {
     if (req.session.data.edited) res.redirect('/check-answers')
     res.redirect('/disciplinary')
@@ -115,7 +114,18 @@ router.get('/check-answers', function (req, res) {
 
 router.post('/national-insurance-number', function (req, res) {
   if (req.session.data.edited) res.redirect('/check-answers')
-  res.redirect('/education-country')
+  res.redirect('/repaying-loan')
+})
+
+router.post('/repaying-loan', function (req, res) {
+  let repayingLoan = req.session.data['repayingLoan']
+
+  if (repayingLoan === 'Yes') {
+    if (req.session.data.edited) res.redirect('/check-answers')
+    res.redirect('/education-country')
+  } else {
+    res.redirect('/payment-method')
+  }
 })
 
 router.post('/student-loan-repayment', function (req, res) {

--- a/app/views/check-answers.html
+++ b/app/views/check-answers.html
@@ -208,6 +208,38 @@
         </div>
         {% endif %}
 
+        {% if data['studentLoanRepayment'] %}
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            How much student loan did you repay while you were at SCHOOL between 6 April XXXX and 5 April XXXX?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['studentLoanRepayment'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link" href="/student-loan-repayment">
+              Change<span class="govuk-visually-hidden"> your student loan repayment amount</span>
+            </a>
+          </dd>
+        </div>
+        {% endif %}
+
+        {% if data['studentLoanPlan'] %}
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            What student loan repayment plan do you have?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['studentLoanPlan'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link" href="/student-loan-plan">
+              Change<span class="govuk-visually-hidden"> your student loan repayment plan</span>
+            </a>
+          </dd>
+        </div>
+        {% endif %}
+
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
             Your account details

--- a/app/views/check-answers.html
+++ b/app/views/check-answers.html
@@ -217,7 +217,7 @@
             {{ data['repayingLoan'] }}
           </dd>
           <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" href="/student-loan-repayment">
+            <a class="govuk-link" href="/repaying-loan">
               Change<span class="govuk-visually-hidden"> if you have a student loan</span>
             </a>
           </dd>
@@ -233,7 +233,7 @@
             {{ data['studentLoanPlan'] }}
           </dd>
           <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" href="/student-loan-plan">
+            <a class="govuk-link" href="/education-country">
               Change<span class="govuk-visually-hidden"> your student loan repayment plan</span>
             </a>
           </dd>

--- a/app/views/check-answers.html
+++ b/app/views/check-answers.html
@@ -208,17 +208,17 @@
         </div>
         {% endif %}
 
-        {% if data['studentLoanRepayment'] %}
+        {% if data['repayingLoan'] %}
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
-            How much student loan did you repay while you were at SCHOOL between 6 April XXXX and 5 April XXXX?
+            Do you currently have a student loan?
           </dt>
           <dd class="govuk-summary-list__value">
-            {{ data['studentLoanRepayment'] }}
+            {{ data['repayingLoan'] }}
           </dd>
           <dd class="govuk-summary-list__actions">
             <a class="govuk-link" href="/student-loan-repayment">
-              Change<span class="govuk-visually-hidden"> your student loan repayment amount</span>
+              Change<span class="govuk-visually-hidden"> if you have a student loan</span>
             </a>
           </dd>
         </div>

--- a/app/views/course-start.html
+++ b/app/views/course-start.html
@@ -32,7 +32,7 @@
           name: "courseStart",
           fieldset: {
             legend: {
-              text: "When did the first year of your course start?",
+              text: "When did the first year of your higher educaton course start?",
               isPageHeading: true,
               classes: "govuk-fieldset__legend--xl"
             }

--- a/app/views/course-start.html
+++ b/app/views/course-start.html
@@ -1,0 +1,65 @@
+
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  DfE Maths and Physics Service Prototype
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+
+  {{ govukBackLink({
+    text: "Back",
+    href: "/consent"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form method="POST" action="course-start">
+        {% from "radios/macro.njk" import govukRadios %}
+
+        {{ govukRadios({
+          classes: "govuk-radios",
+          idPrefix: "courseStart",
+          name: "courseStart",
+          fieldset: {
+            legend: {
+              text: "When did the first year of your course start?",
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--xl"
+            }
+          },
+          items: [
+            {
+              value: "Plan 1",
+              text: "Before 1 September 2012",
+              attributes: {
+                required: "true"
+              }
+            },
+            {
+              value: "Plan 2",
+              text: "On or after 1 September 2012"
+            }
+          ]
+        }) }}
+
+        {% from "button/macro.njk" import govukButton %}
+
+        {{ govukButton({
+          text: "Continue",
+          preventDoubleClick: true
+        }) }}
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/course-start.html
+++ b/app/views/course-start.html
@@ -15,7 +15,7 @@
 
   {{ govukBackLink({
     text: "Back",
-    href: "/consent"
+    href: "/number-of-courses"
   }) }}
 {% endblock %}
 

--- a/app/views/course-start.html
+++ b/app/views/course-start.html
@@ -39,14 +39,14 @@
           },
           items: [
             {
-              value: "Plan 1",
+              value: "1",
               text: "Before 1 September 2012",
               attributes: {
                 required: "true"
               }
             },
             {
-              value: "Plan 2",
+              value: "2",
               text: "On or after 1 September 2012"
             }
           ]

--- a/app/views/education-country.html
+++ b/app/views/education-country.html
@@ -15,7 +15,7 @@
 
   {{ govukBackLink({
     text: "Back",
-    href: "/consent"
+    href: "/repaying-loan"
   }) }}
 {% endblock %}
 

--- a/app/views/education-country.html
+++ b/app/views/education-country.html
@@ -1,0 +1,73 @@
+
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  DfE Maths and Physics Service Prototype
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+
+  {{ govukBackLink({
+    text: "Back",
+    href: "/consent"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form method="POST" action="education-country">
+        {% from "radios/macro.njk" import govukRadios %}
+
+        {{ govukRadios({
+          classes: "govuk-radios",
+          idPrefix: "educationCountry",
+          name: "educationCountry",
+          fieldset: {
+            legend: {
+              text: "When you first applied for your student loan in which country was your home address?",
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--xl"
+            }
+          },
+          items: [
+            {
+              value: "England",
+              text: "England",
+              attributes: {
+                required: "true"
+              }
+            },
+            {
+              value: "Wales",
+              text: "Wales"
+            },
+            {
+              value: "Northern Ireland",
+              text: "Northern Ireland"
+            },
+            {
+              value: "Scotland",
+              text: "Scotland"
+            }
+          ]
+        }) }}
+
+        {% from "button/macro.njk" import govukButton %}
+
+        {{ govukButton({
+          text: "Continue",
+          preventDoubleClick: true
+        }) }}
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/education-country.html
+++ b/app/views/education-country.html
@@ -28,8 +28,8 @@
 
         {{ govukRadios({
           classes: "govuk-radios",
-          idPrefix: "educationCountry",
-          name: "educationCountry",
+          idPrefix: "countryLoanPlan",
+          name: "countryLoanPlan",
           fieldset: {
             legend: {
               text: "When you first applied for your student loan in which country was your home address?",

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -12,10 +12,10 @@
       <h1 class="govuk-heading-xl">DfE Mathematics and Physics Service Prototypes</h1>
     </div>
   </div>
-  
+
   <h2 class="govuk-heading-l">Beta Prototypes</h2>
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-half">
+    <div class="govuk-grid-column-one-third">
       <h3 class="govuk-heading-m">Beta 1 <small class="sub-heading">Check Eligibiity</small><small class="sub-heading">8th May 2019</small></h3>
 
       <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
@@ -46,12 +46,12 @@
         </div>
       </details>
     </div>
-    <div class="govuk-grid-column-one-half">
-      <h3 class="govuk-heading-m">Beta 2 <small class="sub-heading">Re-word/order questions</small><small class="sub-heading">15th May 2019</small></h3>
+    <div class="govuk-grid-column-one-third">
+      <h3 class="govuk-heading-m">Beta 2 <small class="sub-heading">Re-word/order questions</small><small class="sub-heading">11th June 2019</small></h3>
       <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
       <ul class="govuk-list">
         <li>
-          <a href="/start" class="govuk-link" target="_blank">Teacher journey</a>
+          <a href="https://dfe-mps-prototype-beta-2.herokuapp.com/start" class="govuk-link" target="_blank">Teacher journey</a>
         </li>
       </ul>
       <details class="govuk-details">
@@ -70,6 +70,31 @@
             <li>Redesigned confirmation page</li>
             <li>Redesigned consent page</li>
             <li>Additional Q routes such as degree Q if teacher hasn't completed ITT</li>
+          </ul>
+          <h4 class="govuk-heading-s govuk-!-margin-bottom-1">Research</h4>
+          <p>Will be  entering research this sprint.</p>
+        </div>
+      </details>
+    </div>
+    <div class="govuk-grid-column-one-third">
+      <h3 class="govuk-heading-m">Beta 3 <small class="sub-heading">Include Student Loan</small><small class="sub-heading">Latest</small></h3>
+      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+      <ul class="govuk-list">
+        <li>
+          <a href="/start" class="govuk-link" target="_blank">Teacher journey</a>
+        </li>
+      </ul>
+      <details class="govuk-details">
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">
+            What's new?
+          </span>
+        </summary>
+        <div class="govuk-details__text">
+          <ul class="govuk-list govuk-list--bullet">
+            <li>Introduce student loan plan questions</li>
+            <li>Updated content design on questions</li>
+            <li>Change to Verify to use LOA2</li>
           </ul>
           <h4 class="govuk-heading-s govuk-!-margin-bottom-1">Research</h4>
           <p>Will be  entering research this sprint.</p>

--- a/app/views/multiple-courses-start.html
+++ b/app/views/multiple-courses-start.html
@@ -32,7 +32,7 @@
           name: "multipleCoursesStart",
           fieldset: {
             legend: {
-              text: "When did the first year of each course start?",
+              text: "When did the first year of each higher education course start?",
               isPageHeading: true,
               classes: "govuk-fieldset__legend--xl"
             }

--- a/app/views/multiple-courses-start.html
+++ b/app/views/multiple-courses-start.html
@@ -23,13 +23,13 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <form method="POST" action="course-start">
+      <form method="POST" action="multiple-courses-start">
         {% from "radios/macro.njk" import govukRadios %}
 
         {{ govukRadios({
           classes: "govuk-radios",
-          idPrefix: "studentLoanPlan",
-          name: "studentLoanPlan",
+          idPrefix: "multipleCoursesStart",
+          name: "multipleCoursesStart",
           fieldset: {
             legend: {
               text: "When did the first year of each course start?",
@@ -39,19 +39,19 @@
           },
           items: [
             {
-              value: "Plan 1",
+              value: "1",
               text: "All my degree courses started before 1 September 2012",
               attributes: {
                 required: "true"
               }
             },
             {
-              value: "Plan 1 and 2",
+              value: "2",
               text: "Some of my degree courses started before 1 September 2012 and some started after 1 September 2012"
             }
             ,
             {
-              value: "Plan 2",
+              value: "3",
               text: "All of my degree courses started after 1 September 2012"
             }
           ]

--- a/app/views/multiple-courses-start.html
+++ b/app/views/multiple-courses-start.html
@@ -1,0 +1,70 @@
+
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  DfE Maths and Physics Service Prototype
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+
+  {{ govukBackLink({
+    text: "Back",
+    href: "/consent"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form method="POST" action="course-start">
+        {% from "radios/macro.njk" import govukRadios %}
+
+        {{ govukRadios({
+          classes: "govuk-radios",
+          idPrefix: "studentLoanPlan",
+          name: "studentLoanPlan",
+          fieldset: {
+            legend: {
+              text: "When did the first year of each course start?",
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--xl"
+            }
+          },
+          items: [
+            {
+              value: "Plan 1",
+              text: "All my degree courses started before 1 September 2012",
+              attributes: {
+                required: "true"
+              }
+            },
+            {
+              value: "Plan 1 and 2",
+              text: "Some of my degree courses started before 1 September 2012 and some started after 1 September 2012"
+            }
+            ,
+            {
+              value: "Plan 2",
+              text: "All of my degree courses started after 1 September 2012"
+            }
+          ]
+        }) }}
+
+        {% from "button/macro.njk" import govukButton %}
+
+        {{ govukButton({
+          text: "Continue",
+          preventDoubleClick: true
+        }) }}
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/number-of-courses.html
+++ b/app/views/number-of-courses.html
@@ -1,0 +1,65 @@
+
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  DfE Maths and Physics Service Prototype
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+
+  {{ govukBackLink({
+    text: "Back",
+    href: "/consent"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form method="POST" action="number-of-courses">
+        {% from "radios/macro.njk" import govukRadios %}
+
+        {{ govukRadios({
+          classes: "govuk-radios",
+          idPrefix: "numberOfCourses",
+          name: "numberOfCourses",
+          fieldset: {
+            legend: {
+              text: "How many courses have you studied?",
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--xl"
+            }
+          },
+          items: [
+            {
+              value: "1 course",
+              text: "1 course",
+              attributes: {
+                required: "true"
+              }
+            },
+            {
+              value: "2 or more courses",
+              text: "2 or more courses"
+            }
+          ]
+        }) }}
+
+        {% from "button/macro.njk" import govukButton %}
+
+        {{ govukButton({
+          text: "Continue",
+          preventDoubleClick: true
+        }) }}
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/number-of-courses.html
+++ b/app/views/number-of-courses.html
@@ -32,10 +32,13 @@
           name: "numberOfCourses",
           fieldset: {
             legend: {
-              text: "How many courses have you studied?",
+              text: "How many higher education courses have you studied?",
               isPageHeading: true,
               classes: "govuk-fieldset__legend--xl"
             }
+          },
+          hint: {
+            text: "This includes unniversity degree, PGCE and Initial Teacher Training courses."
           },
           items: [
             {

--- a/app/views/number-of-courses.html
+++ b/app/views/number-of-courses.html
@@ -15,7 +15,7 @@
 
   {{ govukBackLink({
     text: "Back",
-    href: "/consent"
+    href: "/number-of-courses"
   }) }}
 {% endblock %}
 

--- a/app/views/payment-method.html
+++ b/app/views/payment-method.html
@@ -29,7 +29,7 @@
 
         {% call govukFieldset({
           legend: {
-            text: "Your bank account details",
+            text: "Enter bank account details",
             isPageHeading: true,
             classes: "govuk-fieldset__legend--xl"
           }

--- a/app/views/repaying-loan.html
+++ b/app/views/repaying-loan.html
@@ -1,0 +1,62 @@
+
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  DfE Maths and Physics Service Prototype
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+
+  {{ govukBackLink({
+    text: "Back",
+    href: "/consent"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form method="POST" action="repaying-loan">
+        {% from "radios/macro.njk" import govukRadios %}
+
+        {{ govukRadios({
+          classes: "govuk-radios",
+          idPrefix: "repayingLoan",
+          name: "repayingLoan",
+          fieldset: {
+            legend: {
+              text: "Do you have a studet loan?",
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--xl"
+            }
+          },
+          items: [
+            {
+              value: "Yes",
+              text: "Yes"
+            },
+            {
+              value: "No",
+              text: "No"
+            }
+          ]
+        }) }}
+
+        {% from "button/macro.njk" import govukButton %}
+
+        {{ govukButton({
+          text: "Continue",
+          preventDoubleClick: true
+        }) }}
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/repaying-loan.html
+++ b/app/views/repaying-loan.html
@@ -15,7 +15,7 @@
 
   {{ govukBackLink({
     text: "Back",
-    href: "/consent"
+    href: "/national-insurance-number"
   }) }}
 {% endblock %}
 
@@ -32,7 +32,7 @@
           name: "repayingLoan",
           fieldset: {
             legend: {
-              text: "Do you currently have a studet loan?",
+              text: "Do you currently have a student loan?",
               isPageHeading: true,
               classes: "govuk-fieldset__legend--xl"
             }

--- a/app/views/repaying-loan.html
+++ b/app/views/repaying-loan.html
@@ -32,7 +32,7 @@
           name: "repayingLoan",
           fieldset: {
             legend: {
-              text: "Do you have a studet loan?",
+              text: "Do you currently have a studet loan?",
               isPageHeading: true,
               classes: "govuk-fieldset__legend--xl"
             }

--- a/app/views/student-loan-plan.html
+++ b/app/views/student-loan-plan.html
@@ -1,0 +1,76 @@
+
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  DfE Maths and Physics Service Prototype
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+
+  {{ govukBackLink({
+    text: "Back",
+    href: "/consent"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form method="POST" action="student-loan-plan">
+        {% from "radios/macro.njk" import govukRadios %}
+
+        {{ govukRadios({
+          classes: "govuk-radios",
+          idPrefix: "studentLoanPlan",
+          name: "studentLoanPlan",
+          fieldset: {
+            legend: {
+              text: "What student loan repayment plan do you have?",
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--xl"
+            }
+          },
+          hint: {
+            text: "You can find this on pages 1 and 2 of your student loan annual statment."
+          },
+          items: [
+            {
+              value: "Plan 1",
+              text: "Plan 1"
+            },
+            {
+              value: "Plan 2",
+              text: "Plan 2"
+            },
+            {
+               value: "Plan 1 and 2",
+              text: "Plan 1 and 2"
+            },
+            {
+              divider: "or"
+            },
+            {
+              value: "I do not know",
+              text: "I do not know"
+            }
+          ]
+        }) }}
+
+        {% from "button/macro.njk" import govukButton %}
+
+        {{ govukButton({
+          text: "Continue",
+          preventDoubleClick: true
+        }) }}
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/student-loan-repayment.html
+++ b/app/views/student-loan-repayment.html
@@ -1,0 +1,50 @@
+
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  DfE Maths and Physics Service Prototype
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+
+  {{ govukBackLink({
+    text: "Back",
+    href: "/consent"
+  }) }}
+{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      How much student loan did you repay while you were at SCHOOL between 6 April XXXX and 5 April XXXX?
+    </h1>
+    <form method="POST" action="student-loan-repayment">
+      {% from "input/macro.njk" import govukInput %}
+
+      {{ govukInput({
+        hint: {
+          text: "Only include repayments made through your teaching wages. You can find this information on your payslips."
+        },
+        id: "studentLoanRepayment",
+        name: "studentLoanRepayment",
+        classes: "govuk-input--width-5"
+      }) }}
+
+      {% from "button/macro.njk" import govukButton %}
+
+      {{ govukButton({
+                text: "Continue",
+                preventDoubleClick: true
+              }) }}
+    </form>
+  </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
Change the journey so we can capture what loan plan they are on. After an initial review we felt it was better to ask questions to identify a users loan plan rather than to ask them to locate that information.