### PR TITLE
Change the contact method to text or email

### DIFF
--- a/app/views/contact-method.html
+++ b/app/views/contact-method.html
@@ -24,65 +24,67 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <form method="POST" action="check-answers">
-        {% from "checkboxes/macro.njk" import govukCheckboxes %}
-        {% from "input/macro.njk" import govukInput %}
 
-        {% set emailAddress %}
-        {{ govukInput({
-          id: "contactEmail",
-          name: "contactEmail",
-          type: "email",
-          label: {
-            text: "Email address"
-          },
-          attributes: {
-            spellcheck: "false"
-          }
-        }) }}
-        {% endset -%}
+          {% from "radios/macro.njk" import govukRadios %}
+          {% from "input/macro.njk" import govukInput %}
 
-        {% set textNumber %}
-        {{ govukInput({
-          id: "contactText",
-          name: "contactText",
-          classes: "govuk-!-width-one-third",
-          type: "tel",
-          label: {
-            text: "Mobile phone number"
-          }
-        }) }}
-        {% endset -%}
-
-        {{ govukCheckboxes({
-          idPrefix: "contactMethod",
-          name: "contactMethod",
-          fieldset: {
-            legend: {
-              text: "How do you want us to contact you?",
-              isPageHeading: true,
-              classes: "govuk-fieldset__legend--xl"
+          {% set emailAddress %}
+          {{ govukInput({
+            id: "contactEmail",
+            name: "contactEmail",
+            type: "email",
+            classes: "govuk-width-one-half",
+            label: {
+              text: "Email address"
+            },
+            attributes: {
+              spellcheck: "false"
             }
-          },
-          hint: {
-            text: "We'll only use these details to update you about your claim."
-          },
-          items: [
-            {
-              value: "email",
-              text: "Email",
-              conditional: {
-                html: emailAddress
+          }) }}
+          {% endset -%}
+
+          {% set textNumber %}
+          {{ govukInput({
+            id: "contactText",
+            name: "contactText",
+            type: "tel",
+            classes: "govuk-!-width-one-third",
+            label: {
+              text: "Mobile phone number"
+            }
+          }) }}
+          {% endset -%}
+
+          {{ govukRadios({
+            idPrefix: "how-contacted-conditional",
+            name: "how-contacted",
+            fieldset: {
+              legend: {
+                text: "How do you want us to contact you?",
+                isPageHeading: true,
+                classes: "govuk-fieldset__legend--xl"
               }
             },
-            {
-              value: "text message",
-              text: "Text message",
-              conditional: {
-                html: textNumber
+            hint: {
+              text: "We'll only use these details to update you about your claim."
+            },
+            items: [
+              {
+                value: "email",
+                text: "Email",
+                conditional: {
+                  html: emailAddress
+                }
+              },
+              {
+                value: "text",
+                text: "Text message",
+                conditional: {
+                  html: textNumber
+                }
               }
-            }
-          ]
-        }) }}
+            ]
+          }) }}
 
         {% from "button/macro.njk" import govukButton %}
 

--- a/app/views/contact-method.html
+++ b/app/views/contact-method.html
@@ -24,67 +24,25 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <form method="POST" action="check-answers">
+          <h1 class="govuk-heading-xl">Email Address</h1>
 
           {% from "radios/macro.njk" import govukRadios %}
           {% from "input/macro.njk" import govukInput %}
 
-          {% set emailAddress %}
           {{ govukInput({
             id: "contactEmail",
             name: "contactEmail",
             type: "email",
             classes: "govuk-width-one-half",
-            label: {
-              text: "Email address"
+            hint: {
+              text: "We will only use your email address to update you about your claim."
             },
             attributes: {
               spellcheck: "false"
             }
           }) }}
-          {% endset -%}
 
-          {% set textNumber %}
-          {{ govukInput({
-            id: "contactText",
-            name: "contactText",
-            type: "tel",
-            classes: "govuk-!-width-one-third",
-            label: {
-              text: "Mobile phone number"
-            }
-          }) }}
-          {% endset -%}
 
-          {{ govukRadios({
-            idPrefix: "how-contacted-conditional",
-            name: "how-contacted",
-            fieldset: {
-              legend: {
-                text: "How do you want us to contact you?",
-                isPageHeading: true,
-                classes: "govuk-fieldset__legend--xl"
-              }
-            },
-            hint: {
-              text: "We'll only use these details to update you about your claim."
-            },
-            items: [
-              {
-                value: "email",
-                text: "Email",
-                conditional: {
-                  html: emailAddress
-                }
-              },
-              {
-                value: "text",
-                text: "Text message",
-                conditional: {
-                  html: textNumber
-                }
-              }
-            ]
-          }) }}
 
         {% from "button/macro.njk" import govukButton %}
 


### PR DESCRIPTION
Previously we allowed users to specify an email address and mobile phone
number so that they could be contacted using both menthods. In UR
it appears that most users would choose email so they could dig it out
again. Our hypothesis that we are testing is that they don't need or
care about multiple contact methods.